### PR TITLE
Accessible form mark up

### DIFF
--- a/about_me.html
+++ b/about_me.html
@@ -53,8 +53,9 @@
 
             <div class="col-md-6 col-sm-11 col-11 py-2">
               <form class="form-inline my-2 my-lg-0 float-right">
-                <input class="form-control mr-sm-2 w-auto" type="search" placeholder="Search" aria-label="Search">
-                <button class="btn btn-outline my-sm-0" type="submit">Search</button>
+                <label class="sr-only" for="search">Search</label>
+                <input class="form-control mr-sm-2 w-auto" id="search" type="search" placeholder="Enter search term..." aria-label="Search">
+                <input class="btn btn-outline my-sm-0" type="submit" value="Search" />
               </form>
             </div>
           </div>
@@ -159,9 +160,11 @@
             </p>
             <div class="form-group">
               <form>
-                <input type="text" class="form-control small-field mb-2" placeholder="Enter fullname">
-                <input type="email" class="form-control small-field mb-2" placeholder="Enter email">
-                <button type="submit" class="btn btn-sm btn-block btn-primary">Subscribe Today!</button>
+                <label class="sr-only" for="subscription-name">Full Name</label>
+                <input type="text" id="subscription-name" class="form-control small-field mb-2" placeholder="Enter full name">
+                <label class="sr-only" for="subscription-email">Email</label>
+                <input type="email" id="subscription-email" class="form-control small-field mb-2" placeholder="Enter email">
+                <input type="submit" class="btn btn-sm btn-block btn-primary" value="Subscribe Today!" />
               </form>
             </div>
           </div>

--- a/contact_me.html
+++ b/contact_me.html
@@ -53,8 +53,9 @@
 
             <div class="col-md-6 col-sm-11 col-11 py-2">
               <form class="form-inline my-2 my-lg-0 float-right">
-                <input class="form-control mr-sm-2 w-auto" type="search" placeholder="Search" aria-label="Search">
-                <button class="btn btn-outline my-sm-0" type="submit">Search</button>
+               <label class="sr-only" for="search">Search</label>
+                <input class="form-control mr-sm-2 w-auto" id="search" type="search" placeholder="Enter search term..." aria-label="Search">
+                <input class="btn btn-outline my-sm-0" type="submit" value="Search" />
               </form>
             </div>
           </div>
@@ -90,10 +91,15 @@
 
             <div class="mt-5">
               <form>
-                <input type="text" class="form-control small-field mb-2" placeholder="Enter fullname">
-                <input type="email" class="form-control small-field mb-2" placeholder="Enter email">
-                <textarea class="form-control small-field mb-2" rows="4" placeholder="Enter message"></textarea>
-                <button type="submit" class="btn btn-sm btn-block btn-primary">Send Message</button>
+                <label class="small" for="full-name">Full Name</label>
+                <input type="text" id="full-name" class="form-control small-field mb-2" placeholder="Enter full name">
+                <label class="small" for="email">Email</label>
+                <input type="email" id="email" class="form-control small-field mb-2" placeholder="Enter email">
+                <label class="small" for="number">Contact Number</label>
+                <input type="tel" id="number" class="form-control small-field mb-2" placeholder="Enter contact number">
+                <label class="small" for="message">Message</label>
+                <textarea class="form-control small-field mb-2" id="message" rows="4" placeholder="Enter message"></textarea>
+                <input type="submit" class="btn btn-sm btn-block btn-primary" value="Send Message" >
               </form>
             </div>
           </div>
@@ -113,9 +119,11 @@
             </p>
             <div class="form-group">
               <form>
-                <input type="text" class="form-control small-field mb-2" placeholder="Enter fullname">
-                <input type="email" class="form-control small-field mb-2" placeholder="Enter email">
-                <button type="submit" class="btn btn-sm btn-block btn-primary">Subscribe Today!</button>
+                <label class="sr-only" for="subscription-name">Full Name</label>
+                <input type="text" id="subscription-name" class="form-control small-field mb-2" placeholder="Enter full name">
+                <label class="sr-only" for="subscription-email">Email</label>
+                <input type="email" id="subscription-email" class="form-control small-field mb-2" placeholder="Enter email">
+                <input type="submit" class="btn btn-sm btn-block btn-primary" value="Subscribe Today!" />
               </form>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -53,8 +53,9 @@
 
             <div class="col-md-6 col-sm-11 col-11 py-2">
               <form class="form-inline my-2 my-lg-0 float-right">
-                <input class="form-control mr-sm-2 w-auto" type="search" placeholder="Search" aria-label="Search">
-                <button class="btn btn-outline my-sm-0" type="submit">Search</button>
+                <label for="search" class="sr-only">Search</label>
+                <input class="form-control mr-sm-2 w-auto" id="search" type="search" placeholder="Enter search term..." aria-label="Search">
+                <input class="btn btn-outline my-sm-0" type="submit" value="Search" />
               </form>
             </div>
           </div>
@@ -167,9 +168,11 @@
             </p>
             <div class="form-group">
               <form>
-                <input type="text" class="form-control small-field mb-2" placeholder="Enter fullname">
-                <input type="email" class="form-control small-field mb-2" placeholder="Enter email">
-                <button type="submit" class="btn btn-sm btn-block btn-primary">Subscribe Today!</button>
+                <label class="sr-only" for="subscription-name">Full Name</label>
+                <input type="text" id="subscription-name" class="form-control small-field mb-2" placeholder="Enter full name">
+                <label class="sr-only" for="subscription-email">Email</label>
+                <input type="email" id="subscription-email" class="form-control small-field mb-2" placeholder="Enter email">
+                <input type="submit" class="btn btn-sm btn-block btn-primary" value="Subscribe Today!" />
               </form>
             </div>
           </div>

--- a/post_details.html
+++ b/post_details.html
@@ -53,8 +53,9 @@
 
             <div class="col-md-6 col-sm-11 col-11 py-2">
               <form class="form-inline my-2 my-lg-0 float-right">
-                <input class="form-control mr-sm-2 w-auto" type="search" placeholder="Search" aria-label="Search">
-                <button class="btn btn-outline my-sm-0" type="submit">Search</button>
+                <label for="search" class="sr-only">Search</label>
+                <input class="form-control mr-sm-2 w-auto" id="search" type="search" placeholder="Enter search term..." aria-label="Search">
+                <input class="btn btn-outline my-sm-0" type="submit" value="Search" />
               </form>
             </div>
           </div>
@@ -110,9 +111,11 @@
             <p class="mb-1 small">Leave a comment:</p>
             <form>
               <div class="clearfix">
-                <input type="text" class="form-control small-field mb-2" placeholder="Fullname">
-                <textarea class="form-control small-field" rows="3" placeholder="Comment"></textarea>
-                <button type="submit" class="btn btn-sm btn-primary btn-block mt-2">Submit Comment</button>
+                <label class="small" for="comment-name">Full Name</label>
+                <input id="comment-name" type="text" class="form-control small-field mb-2" placeholder="Enter full name">
+                <label class="small" for="comment">Comment</label>
+                <textarea id="comment" class="form-control small-field" rows="3" placeholder="Enter comment"></textarea>
+                <input type="submit" class="btn btn-sm btn-primary btn-block mt-2" value="Submit Comment" />
               </div>
             </form>
 
@@ -143,9 +146,11 @@
                 <div id="collapsedReplyForm-id-1" class="collapse mb-2">
                   <form>
                     <div class="clearfix">
-                      <input type="text" class="form-control mb-2 small-field" placeholder="Fullname">
-                      <textarea class="form-control small-field" rows="3" placeholder="Comment"></textarea>
-                      <button type="submit" class="btn btn-sm btn-primary btn-block mt-2">Submit Comment</button>
+                      <label class="sr-only" for="subscription-name">Full Name</label>
+                      <input type="text" id="subscription-name" class="form-control small-field mb-2" placeholder="Enter full name">
+                      <label class="sr-only" for="subscription-email">Email</label>
+                      <input type="email" id="subscription-email" class="form-control small-field mb-2" placeholder="Enter email">
+                      <input type="submit" class="btn btn-sm btn-block btn-primary" value="Subscribe Today!" />
                     </div>
                   </form>
                 </div>


### PR DESCRIPTION
- `sr-only` has been used on the footer mailing list labels and search in header only. To show that there are cases when it’s easier to hide labels for lack of space in design. But we generally steer the designers away from hiding all labels by default. It negatively affects usability because once the input has text in there is nothing to say what the input is.

- I changed the placeholders to be different to the labels so the forms that do have visible labels do not seem repetitive. Also don't want to give the impression that a placeholder is an alternative or as useful as a label. Placeholders are optional, labels are not.
